### PR TITLE
Initialize a Channel to push to

### DIFF
--- a/pushbullet_cli/app.py
+++ b/pushbullet_cli/app.py
@@ -67,7 +67,7 @@ def _push(data_type, title=None, message=None, channel=None, device=None, file_p
         data.update(file_data)
 
     if channel is not None:
-        pb = channel
+        pb = pushbullet.channel.Channel(pb, {'tag': channel })
 
     if data_type == "file":
         pb.push_file(**data)


### PR DESCRIPTION
The channel parameter is a passed string not a Pushbullet object and so it causes the CLI to throw an exception.