### PR TITLE
Default title only when not explicitly set

### DIFF
--- a/pushbullet_cli/app.py
+++ b/pushbullet_cli/app.py
@@ -65,7 +65,7 @@ def _push(data_type, title=None, message=None, channel=None, device=None, file_p
     elif data_type == "url":
         pb.push_link(title=title or url, url=url, **data)
     elif data_type == "text":
-        pb.push_note(title=title or "Note", **data)
+        pb.push_note(title=title if title is not None else "Note", **data)
     else:
         raise Exception("Unknown data type")
 


### PR DESCRIPTION
Allows push with no title via:

    pb push -t "" "Hello world!"